### PR TITLE
Add mesos-master versions 0.25.0 and 0.26.0 for Centos 7 and Ubuntu 1…

### DIFF
--- a/.monty.yml
+++ b/.monty.yml
@@ -1,9 +1,31 @@
+- build: 0.26.0/centos/7
+  image:
+    - mesoscloud/mesos-master:0.26.0-centos-7
+    - mesoscloud/mesos-master:0.26.0-centos
+    - mesoscloud/mesos-master:0.26.0
+    - mesoscloud/mesos-master:latest
+
+- build: 0.26.0/ubuntu/14.04
+  image:
+    - mesoscloud/mesos-master:0.26.0-ubuntu-14.04
+    - mesoscloud/mesos-master:0.26.0-ubuntu
+
+- build: 0.25.0/centos/7
+  image:
+    - mesoscloud/mesos-master:0.25.0-centos-7
+    - mesoscloud/mesos-master:0.25.0-centos
+    - mesoscloud/mesos-master:0.25.0
+
+- build: 0.25.0/ubuntu/14.04
+  image:
+    - mesoscloud/mesos-master:0.25.0-ubuntu-14.04
+    - mesoscloud/mesos-master:0.25.0-ubuntu
+
 - build: 0.24.1/centos/7
   image:
     - mesoscloud/mesos-master:0.24.1-centos-7
     - mesoscloud/mesos-master:0.24.1-centos
     - mesoscloud/mesos-master:0.24.1
-    - mesoscloud/mesos-master:latest
 
 - build: 0.24.1/ubuntu/14.04
   image:

--- a/0.25.0/centos/7/Dockerfile
+++ b/0.25.0/centos/7/Dockerfile
@@ -1,0 +1,14 @@
+FROM centos:7
+
+RUN rpm -i http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm && \
+yum -y install mesos-0.25.0
+
+CMD ["/usr/sbin/mesos-master"]
+
+ENV MESOS_WORK_DIR /tmp/mesos
+
+VOLUME /tmp/mesos
+
+COPY entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/0.25.0/centos/7/entrypoint.sh
+++ b/0.25.0/centos/7/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+PRINCIPAL=${PRINCIPAL:-root}
+
+if [ -n "$SECRET" ]; then
+    export MESOS_AUTHENTICATE=true
+    export MESOS_AUTHENTICATE_SLAVES=true
+    touch /tmp/credentials
+    chmod 600 /tmp/credentials
+    echo -n "$PRINCIPAL $SECRET" > /tmp/credentials
+    export MESOS_CREDENTIALS=/tmp/credentials
+fi
+
+exec "$@"

--- a/0.25.0/ubuntu/14.04/Dockerfile
+++ b/0.25.0/ubuntu/14.04/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:14.04
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
+echo deb http://repos.mesosphere.io/ubuntu trusty main > /etc/apt/sources.list.d/mesosphere.list && \
+apt-get update && \
+apt-get -y install mesos=0.25.0-0.2.70.ubuntu1404
+
+CMD ["/usr/sbin/mesos-master"]
+
+ENV MESOS_WORK_DIR /tmp/mesos
+
+VOLUME /tmp/mesos
+
+COPY entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/0.25.0/ubuntu/14.04/entrypoint.sh
+++ b/0.25.0/ubuntu/14.04/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+PRINCIPAL=${PRINCIPAL:-root}
+
+if [ -n "$SECRET" ]; then
+    export MESOS_AUTHENTICATE=true
+    export MESOS_AUTHENTICATE_SLAVES=true
+    touch /tmp/credentials
+    chmod 600 /tmp/credentials
+    echo -n "$PRINCIPAL $SECRET" > /tmp/credentials
+    export MESOS_CREDENTIALS=/tmp/credentials
+fi
+
+exec "$@"

--- a/0.26.0/centos/7/Dockerfile
+++ b/0.26.0/centos/7/Dockerfile
@@ -1,0 +1,14 @@
+FROM centos:7
+
+RUN rpm -i http://repos.mesosphere.io/el/7/noarch/RPMS/mesosphere-el-repo-7-1.noarch.rpm && \
+yum -y install mesos-0.26.0
+
+CMD ["/usr/sbin/mesos-master"]
+
+ENV MESOS_WORK_DIR /tmp/mesos
+
+VOLUME /tmp/mesos
+
+COPY entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/0.26.0/centos/7/entrypoint.sh
+++ b/0.26.0/centos/7/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+PRINCIPAL=${PRINCIPAL:-root}
+
+if [ -n "$SECRET" ]; then
+    export MESOS_AUTHENTICATE=true
+    export MESOS_AUTHENTICATE_SLAVES=true
+    touch /tmp/credentials
+    chmod 600 /tmp/credentials
+    echo -n "$PRINCIPAL $SECRET" > /tmp/credentials
+    export MESOS_CREDENTIALS=/tmp/credentials
+fi
+
+exec "$@"

--- a/0.26.0/ubuntu/14.04/Dockerfile
+++ b/0.26.0/ubuntu/14.04/Dockerfile
@@ -1,0 +1,16 @@
+FROM ubuntu:14.04
+
+RUN apt-key adv --keyserver keyserver.ubuntu.com --recv E56151BF && \
+echo deb http://repos.mesosphere.io/ubuntu trusty main > /etc/apt/sources.list.d/mesosphere.list && \
+apt-get update && \
+apt-get -y install mesos=0.26.0-0.2.145.ubuntu1404
+
+CMD ["/usr/sbin/mesos-master"]
+
+ENV MESOS_WORK_DIR /tmp/mesos
+
+VOLUME /tmp/mesos
+
+COPY entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/0.26.0/ubuntu/14.04/entrypoint.sh
+++ b/0.26.0/ubuntu/14.04/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+PRINCIPAL=${PRINCIPAL:-root}
+
+if [ -n "$SECRET" ]; then
+    export MESOS_AUTHENTICATE=true
+    export MESOS_AUTHENTICATE_SLAVES=true
+    touch /tmp/credentials
+    chmod 600 /tmp/credentials
+    echo -n "$PRINCIPAL $SECRET" > /tmp/credentials
+    export MESOS_CREDENTIALS=/tmp/credentials
+fi
+
+exec "$@"


### PR DESCRIPTION
Hi --

I added support for mesos-master version 0.25.0 and 0.26.0 for both CentOS 7 and Ubuntu 14.04.

Thanks!

Kevin
